### PR TITLE
Typo in table name Alias_attributes in imdb-create-tables.sql

### DIFF
--- a/imdb-create-tables.sql
+++ b/imdb-create-tables.sql
@@ -87,7 +87,7 @@ CREATE TABLE Alias_types (
   type				  VARCHAR(255) NOT NULL-- Only stored if not null
 );
 
-CREATE TABLE ALias_attributes (
+CREATE TABLE Alias_attributes (
   title_id			VARCHAR(255) NOT NULL, -- not null bc PK
   ordering			INTEGER NOT NULL, -- not null bc PK
   attribute			VARCHAR(255) NOT NULL -- only stored if not null


### PR DESCRIPTION
Typo in table name Alias_attributes in imdb-create-tables.sql